### PR TITLE
fix: pin to version until semantic release fix

### DIFF
--- a/.github/workflows/reusable-build-and-push.yml
+++ b/.github/workflows/reusable-build-and-push.yml
@@ -116,7 +116,7 @@ jobs:
           
       - name: Install python tools
         run: |
-          pip install python-semantic-release poetry
+          pip install python-semantic-release==7.28.1 poetry
         
       - name: Get next version information
         id: get-next-version-information


### PR DESCRIPTION
semantic release did not work if version was in comment. there seems
to be a solution on the way until pin version to prior 29 as suggested here:
https://github.com/relekang/python-semantic-release/issues/442#issuecomment-1128878016